### PR TITLE
Prose Pod API admin interface

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins/mod_admin_rest"]
+	path = plugins/mod_admin_rest
+	url = https://github.com/RemiBardon/prosody-mod_admin_rest.git

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -75,13 +75,14 @@ install-util: util/encodings.so util/encodings.so util/pposix.so util/signal.so 
 
 install-plugins:
 	$(MKDIR) $(MODULES)
-	$(MKDIR) $(MODULES)/mod_pubsub $(MODULES)/adhoc $(MODULES)/muc $(MODULES)/mod_mam $(MODULES)/mod_debug_stanzas
+	$(MKDIR) $(MODULES)/mod_pubsub $(MODULES)/adhoc $(MODULES)/muc $(MODULES)/mod_mam $(MODULES)/mod_debug_stanzas $(MODULES)/mod_admin_rest
 	$(INSTALL_DATA) plugins/*.lua $(MODULES)
 	$(INSTALL_DATA) plugins/mod_pubsub/*.lua $(MODULES)/mod_pubsub
 	$(INSTALL_DATA) plugins/adhoc/*.lua $(MODULES)/adhoc
 	$(INSTALL_DATA) plugins/muc/*.lua $(MODULES)/muc
 	$(INSTALL_DATA) plugins/mod_mam/*.lua $(MODULES)/mod_mam
 	$(INSTALL_DATA) plugins/mod_debug_stanzas/*.lua $(MODULES)/mod_debug_stanzas
+	$(INSTALL_DATA) plugins/mod_admin_rest/*.lua $(MODULES)/mod_admin_rest
 
 install-man:
 	$(MKDIR) $(MAN)/man1

--- a/makefile
+++ b/makefile
@@ -77,13 +77,14 @@ install-util: util/encodings.so util/encodings.so util/pposix.so util/signal.so
 
 install-plugins:
 	$(MKDIR) $(MODULES)
-	$(MKDIR) $(MODULES)/mod_pubsub $(MODULES)/adhoc $(MODULES)/muc $(MODULES)/mod_mam $(MODULES)/mod_debug_stanzas
+	$(MKDIR) $(MODULES)/mod_pubsub $(MODULES)/adhoc $(MODULES)/muc $(MODULES)/mod_mam $(MODULES)/mod_debug_stanzas $(MODULES)/mod_admin_rest
 	$(INSTALL_DATA) plugins/*.lua $(MODULES)
 	$(INSTALL_DATA) plugins/mod_pubsub/*.lua $(MODULES)/mod_pubsub
 	$(INSTALL_DATA) plugins/adhoc/*.lua $(MODULES)/adhoc
 	$(INSTALL_DATA) plugins/muc/*.lua $(MODULES)/muc
 	$(INSTALL_DATA) plugins/mod_mam/*.lua $(MODULES)/mod_mam
 	$(INSTALL_DATA) plugins/mod_debug_stanzas/*.lua $(MODULES)/mod_debug_stanzas
+	$(INSTALL_DATA) plugins/mod_admin_rest/*.lua $(MODULES)/mod_admin_rest
 
 install-man:
 	$(MKDIR) $(MAN)/man1

--- a/plugins/mod_auto_activate_hosts.lua
+++ b/plugins/mod_auto_activate_hosts.lua
@@ -1,0 +1,39 @@
+module:set_global();
+
+local hostmanager = require"core.hostmanager";
+
+local array = require "util.array";
+local set = require "util.set";
+local it = require "util.iterators";
+local config = require "core.configmanager";
+
+local function host_not_global(host)
+	return host ~= "*";
+end
+
+local function host_is_enabled(host)
+	return config.get(host, "enabled") ~= false;
+end
+
+function handle_reload()
+	local new_config = config.getconfig();
+	local active_hosts = set.new(array.collect(it.keys(prosody.hosts)):filter(host_not_global));
+	local enabled_hosts = set.new(array.collect(it.keys(new_config)):filter(host_is_enabled):filter(host_not_global));
+	local need_to_activate = enabled_hosts - active_hosts;
+	local need_to_deactivate = active_hosts - enabled_hosts;
+
+	module:log("debug", "Config reloaded... %d hosts need activating, and %d hosts need deactivating", it.count(need_to_activate), it.count(need_to_deactivate));
+	module:log("debug", "There are %d enabled and %d active hosts", it.count(enabled_hosts), it.count(active_hosts));
+	for host in need_to_deactivate do
+		hostmanager.deactivate(host);
+	end
+
+	-- If the lazy loader is loaded, hosts will get activated when they are needed
+	if not(getmetatable(prosody.hosts) and getmetatable(prosody.hosts).lazy_loader) then
+		for host in need_to_activate do
+			hostmanager.activate(host);
+		end
+	end
+end
+
+module:hook_global("config-reloaded", handle_reload);

--- a/plugins/mod_init_admin.lua
+++ b/plugins/mod_init_admin.lua
@@ -21,9 +21,12 @@ local function init_admin()
 
   -- Read JID from Prosody configuration
   local jid = module:get_option_string("init_admin_jid");
+  if not jid then
+    return false, "`init_admin_jid` must be defined in the Prosody configuration file.";
+  end
   local username, host = jid_prepped_split(jid);
   if not (username and host) then
-    return false, "Invalid JID. Check `init_admin_jid`.";
+    return false, "Invalid JID. Check `init_admin_jid` in the Prosody configuration file.";
   end
 
   -- Check that host exists to improve error comprehension (otherwise log is just

--- a/plugins/mod_init_admin.lua
+++ b/plugins/mod_init_admin.lua
@@ -1,0 +1,62 @@
+-----------------------------------------------------------
+-- mod_init_admin: Automatically create an admin account
+-- after Prosody has started.
+-- version 0.1
+-----------------------------------------------------------
+-- Copyright (C) 2024 Rémi Bardon <remi@remibardon.name>
+--
+-- This project is MIT licensed. Please see the LICENSE
+-- file in the source package for more information.
+-----------------------------------------------------------
+
+local jid_prepped_split = require "prosody.util.jid".prepped_split;
+local log = require "prosody.util.logger".init("init_admin");
+local um = require "prosody.core.usermanager";
+
+local prosody = _G.prosody;
+local hosts = prosody.hosts;
+
+local function init_admin()
+  log("debug", "Initializing superadmin account…");
+
+  -- Read JID from Prosody configuration
+  local jid = module:get_option_string("init_admin_jid");
+  local username, host = jid_prepped_split(jid);
+  if not (username and host) then
+    return false, "Invalid JID. Check `init_admin_jid`.";
+  end
+
+  -- Check that host exists to improve error comprehension (otherwise log is just
+  -- `Encountered error: /lib/prosody/core/usermanager.lua:129: attempt to index a nil value (field '?')`
+  -- with a stacktrace)
+  if not hosts[host] then
+    return false, ("`init_admin_jid` is invalid: host `%s` doesn't exist."):format(host);
+  end
+
+  -- Read password from environment
+  local var_name = module:get_option_string("init_admin_password_env_var_name", "SUPERADMIN_PASSWORD");
+  local password = os.getenv(var_name);
+  if not password then
+    return false, ("Environment variable `%s` not defined."):format(var_name);
+  end
+
+  -- Set superadmin account role to "Server operator (full access)"
+  local ok, err = um.create_user_with_role(username, password, host, "prosody:operator");
+  if not ok then
+    return false, ("Could not create user: %s"):format(err);
+  end
+
+  log("info", "Superadmin account created successfully");
+
+  return true
+end
+
+-- Listen to the `"server-started"` event (defined in `util/startup.lua`),
+-- sent once after the server started successfully.
+-- See <https://prosody.im/doc/developers/moduleapi#modulehook_global_event_name_handler_priority>.
+module:hook_global("server-started", function()
+  local ok, err = init_admin();
+  if not ok then
+    log("error", err);
+  end
+end);

--- a/plugins/mod_posix.lua
+++ b/plugins/mod_posix.lua
@@ -69,6 +69,7 @@ local function write_pidfile()
 				pidfile_handle = nil;
 				prosody.shutdown("Prosody already running", 1);
 			else
+				lfs.unlock(pidfile_handle);
 				pidfile_handle:close();
 				pidfile_handle, err = io.open(pidfile, "w+");
 				if not pidfile_handle then
@@ -78,6 +79,7 @@ local function write_pidfile()
 					if lfs.lock(pidfile_handle, "w") then
 						pidfile_handle:write(tostring(pposix.getpid()));
 						pidfile_handle:flush();
+						lfs.unlock(pidfile_handle);
 					end
 				end
 			end

--- a/util/prosodyctl.lua
+++ b/util/prosodyctl.lua
@@ -18,6 +18,8 @@ local set = require "prosody.util.set";
 local lfs = require "lfs";
 local type = type;
 
+local log = require "prosody.util.logger".init("prosodyctl");
+
 local nodeprep, nameprep = stringprep.nodeprep, stringprep.nameprep;
 
 local io, os = io, os;
@@ -39,6 +41,7 @@ local error_messages = setmetatable({
 		["no-posix"] = "The mod_posix module is not enabled in the Prosody config file, see https://prosody.im/doc/prosodyctl for more info";
 		["no-such-method"] = "This module has no commands";
 		["not-running"] = "Prosody is not running";
+		["pidfile-not-locked"] = "Could not lock Prosody's PID file";
 		}, { __index = function (_,k) return "Error: "..(tostring(k):gsub("%-", " "):gsub("^.", string.upper)); end });
 
 -- UI helpers
@@ -118,37 +121,51 @@ local function deluser(params)
 end
 
 local function getpid()
+	-- Get `pidfile` from the configuration
 	local pidfile = config.get("*", "pidfile");
 	if not pidfile then
+		log("error", "Could not find `pidfile` in Prosody config.");
 		return false, "no-pidfile";
 	end
-
 	if type(pidfile) ~= "string" then
+		log("error", "Invalid `pidfile`: not a string.");
 		return false, "invalid-pidfile";
 	end
 
 	pidfile = config.resolve_relative_path(prosody.paths.data, pidfile);
 
+	-- Check if POSIX is supported
 	local modules_disabled = set.new(config.get("*", "modules_disabled"));
-	if prosody.platform ~= "posix" or modules_disabled:contains("posix") then
+	if prosody.platform ~= "posix" then
+		log("error", "Cannot open the PID file: Prosody platform not POSIX.");
+		return false, "no-posix";
+	end
+	if modules_disabled:contains("posix") then
+		log("error", "Cannot open the PID file: `posix` module disabled.");
 		return false, "no-posix";
 	end
 
+	-- Open file in read & write mode
 	local file, err = io.open(pidfile, "r+");
 	if not file then
+		log("error", ("Could not open the PID file: %s"):format(err));
 		return false, "pidfile-read-failed", err;
 	end
 
-	local locked, err = lfs.lock(file, "w"); -- luacheck: ignore 211/err
-	if locked then
+	-- Lock writes to prevent race conditions
+	local locked, err = lfs.lock(file, "w"); -- luacheck: ignore 411/err
+	if not locked then
 		file:close();
+		log("error", ("Could not lock the PID file: %s"):format(err));
 		return false, "pidfile-not-locked";
 	end
 
+	-- Read a PID (number) from the file
 	local pid = tonumber(file:read("*a"));
+	lfs.unlock(file);
 	file:close();
-
 	if not pid then
+		log("error", "Invalid PID: Not a number.");
 		return false, "invalid-pid";
 	end
 
@@ -156,16 +173,27 @@ local function getpid()
 end
 
 local function isrunning()
-	local ok, pid, err = getpid(); -- luacheck: ignore 211/err
+	local ok, pid_or_err = getpid();
 	if not ok then
-		if pid == "pidfile-read-failed" or pid == "pidfile-not-locked" then
+		local err = pid_or_err;
+		if err == "pidfile-read-failed" or err == "pidfile-not-locked" then
 			-- Report as not running, since we can't open the pidfile
 			-- (it probably doesn't exist)
+			log("error", ("Could not get Prosody's PID: %s"):format(error_messages[err]));
 			return true, false;
 		end
-		return ok, pid;
+		return ok, err;
 	end
-	return true, signal.kill(pid, 0) == 0;
+	local pid = pid_or_err;
+
+	-- Test if Prosody is running
+	-- NOTE: As [kill(2)](https://man7.org/linux/man-pages/man2/kill.2.html) states:
+	--   > If sig is 0, then no signal is sent, but error checking is still performed; 
+	--   > this can be used to check for the existence of a process ID or process 
+	--   > group ID.
+	local is_running = signal.kill(pid, 0) == 0;
+
+	return true, is_running;
 end
 
 local function start(source_dir, lua)


### PR DESCRIPTION
Add `mod_admin_rest` to administrate the running Prosody instance via a REST API and `mod_init_admin` to automatically create an admin account for the Prose Pod API.