### PR TITLE
fix: Fix Docker warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=alpine:3.19
 
 # -- STAGE 1 [build] --
 
-FROM ${BASE_IMAGE} as build
+FROM ${BASE_IMAGE} AS build
 
 WORKDIR /build
 
@@ -30,7 +30,7 @@ RUN make install
 
 # -- STAGE 2 [run] --
 
-FROM ${BASE_IMAGE} as run
+FROM ${BASE_IMAGE} AS run
 
 RUN apk add --no-cache \
   libidn \
@@ -72,4 +72,4 @@ EXPOSE 5280/tcp
 
 USER prosody:prosody
 
-ENTRYPOINT prosody
+ENTRYPOINT ["prosody"]


### PR DESCRIPTION
When building the image, Docker would say:

```log
 3 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 5)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 33)
 - JSONArgsRecommended: JSON arguments recommended for ENTRYPOINT to prevent unintended behavior related to OS signals (line 75)
```

See [JSONArgsRecommended | Docker Docs](https://docs.docker.com/reference/build-checks/json-args-recommended/) for explanations regarding the last warning.